### PR TITLE
Use Expo file System

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import {FileSystem} from "expo";
+import * as FileSystem from "expo-file-system";
 
 function generateFolderPath() {
     return FileSystem.documentDirectory + "appData/";

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "react-native"
   ],
   "peerDependencies": {
-    "expo": ">=27"
+    "expo-file-system": ">=5"
   }
 }


### PR DESCRIPTION
Hi, the new expo SDK is recommending the change to expo file system module. In the future they will remove File System from expo itself. 

If this is approved, I would suggest a major version on this library, since this affects everyone using, had to change the peer dependency.